### PR TITLE
Fix nowEpochTime for resolve NoSuchClassError

### DIFF
--- a/src/main/kotlin/com/linecorp/cse/scavenger/adapter/ScavengerAdapter.kt
+++ b/src/main/kotlin/com/linecorp/cse/scavenger/adapter/ScavengerAdapter.kt
@@ -24,10 +24,11 @@ import com.linecorp.cse.scavenger.domain.Customer
 import com.linecorp.cse.scavenger.domain.Snapshot
 import com.linecorp.cse.scavenger.domain.SnapshotNode
 import com.linecorp.cse.scavenger.logging.LoggingSupport.Companion.log
-import kotlinx.html.currentTimeMillis
+import com.linecorp.cse.scavenger.utils.toEpochMilli
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import java.io.IOException
+import java.time.LocalDateTime
 import java.util.concurrent.TimeUnit
 
 @Service(Service.Level.PROJECT)
@@ -40,7 +41,7 @@ class ScavengerAdapter {
     private val gson = Gson()
 
     fun fetchCustomers(baseUrl: String): List<Customer> {
-        val nowEpochTime = currentTimeMillis()
+        val nowEpochTime = LocalDateTime.now().toEpochMilli()
         val path = "$baseUrl/${SCAVENGER_CUSTOMER_API_PREFIX}?_=${nowEpochTime}"
         val request = Request.Builder().url(path).build()
 

--- a/src/main/kotlin/com/linecorp/cse/scavenger/utils/ExtensionUtils.kt
+++ b/src/main/kotlin/com/linecorp/cse/scavenger/utils/ExtensionUtils.kt
@@ -30,6 +30,10 @@ fun Long.epochMillis2LocalDateTime(): LocalDateTime {
     return LocalDateTime.ofInstant(Instant.ofEpochMilli(this), scavengerPluginDefaultTimeZone)
 }
 
+fun LocalDateTime.toEpochMilli(): Long {
+    return atZone(scavengerPluginDefaultTimeZone).toInstant().toEpochMilli()
+}
+
 fun concatenateStrings(vararg args: String): String {
     return args.filter { it.isNotEmpty() }.joinToString(",")
 }


### PR DESCRIPTION
## Issue
* Access to unresolved class `UtilsImpl_jvmKt` (1 problem)
* Method ScavengerAdapter. fetchCustomers (String) references an unresolved class `UtilsImpl_jvnkt`. This can lead to `NoSuchClassError` exception at runtime.

## Fixed
* Add `toEpochMilli` extension method in `ExtensionUtils`
* Fix `nowEpochTime` in `ScavengerAdapter`